### PR TITLE
Removed fixmes, set architectures to all, and add python3-venv to apt dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Shipped version:** 2024.12.4~ynh0
+**Shipped version:** 2024.12.4~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Versión actual:** 2024.12.4~ynh0
+**Versión actual:** 2024.12.4~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Paketatutako bertsioa:** 2024.12.4~ynh0
+**Paketatutako bertsioa:** 2024.12.4~ynh1
 
 **Demoa:** <https://web.esphome.io/>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 ESPHome est un système permettant de contrôler vos microcontrôleurs par des fichiers de configuration simples mais puissants et de les contrôler à distance par le biais de systèmes domotiques. Tout ce que vous avez à faire est d'écrire des fichiers de configuration YAML ; le reste (mises à jour over-the-air, compilation) est entièrement pris en charge par ESPHome.
 
 
-**Version incluse :** 2024.12.4~ynh0
+**Version incluse :** 2024.12.4~ynh1
 
 **Démo :** <https://web.esphome.io/>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Versión proporcionada:** 2024.12.4~ynh0
+**Versión proporcionada:** 2024.12.4~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Versi terkirim:** 2024.12.4~ynh0
+**Versi terkirim:** 2024.12.4~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Geleverde versie:** 2024.12.4~ynh0
+**Geleverde versie:** 2024.12.4~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Dostarczona wersja:** 2024.12.4~ynh0
+**Dostarczona wersja:** 2024.12.4~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Поставляемая версия:** 2024.12.4~ynh0
+**Поставляемая версия:** 2024.12.4~ynh1
 
 **Демо-версия:** <https://web.esphome.io/>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**分发版本：** 2024.12.4~ynh0
+**分发版本：** 2024.12.4~ynh1
 
 **演示：** <https://web.esphome.io/>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -13,7 +13,7 @@ maintainers = ["WGrav01"]
 
 [upstream]
 # NB: Only the "license" key is mandatory. Remove entries for which there's no relevant data
-license = "MIT AND GPL-3.0-only" # you can see the available licenses identifiers list here: https://spdx.org/licenses/
+license = "GPL-3.0" # you can see the available licenses identifiers list here: https://spdx.org/licenses/
 website = "https://esphome.io/"
 demo = "https://web.esphome.io/"
 userdoc = "https://esphome.io"

--- a/manifest.toml
+++ b/manifest.toml
@@ -18,14 +18,12 @@ website = "https://esphome.io/"
 demo = "https://web.esphome.io/"
 userdoc = "https://esphome.io"
 code = "https://github.com/esphome/esphome"
-# FIXME: optional but recommended if relevant, this is meant to contain the Common Platform Enumeration, which is
 # sort of a standard id for applications defined by the NIST. In particular, YunoHost may use this is in the future
 # to easily track CVE (=security reports) related to apps. The CPE may be obtained by searching here:
 # https://nvd.nist.gov/products/cpe/search.
 # For example, for Nextcloud, the CPE is 'cpe:2.3:a:nextcloud:nextcloud' (no need to include the version number)
 cpe = "cpe:2.3:a:esphome:esphome:-:*:*:*:*:*:*:*"
 
-# FIXME: optional but recommended (or remove if irrelevant / not applicable).
 # This is meant to be an URL where people can financially support this app, especially when its development is based
 # on volunteers and/or financed by its community. YunoHost may later advertise it in the webadmin.
 fund = "https://esphome.io/guides/supporters.html"
@@ -33,21 +31,17 @@ fund = "https://esphome.io/guides/supporters.html"
 [integration]
 yunohost = ">= 11.2.30"
 helpers_version = "2.1"
-# FIXME: can be replaced by a list of supported archs using the dpkg --print-architecture nomenclature (amd64/i386/armhf/arm64), for example: ["amd64", "i386"]
-architectures = ["amd64", "armv7", "arm64"]
+architectures = "all"
 multi_instance = true
 
-# FIXME: replace with true, false, or "not_relevant".
 # Not to confuse with the "sso" key: the "ldap" key corresponds to wether or not a user *can* login on the app using
 # its YunoHost credentials.
 ldap = "false"
 
-# FIXME: replace with true, false, or "not_relevant".
 # Not to confuse with the "ldap" key: the "sso" key corresponds to wether or not a user is *automatically logged-in*
 # on the app when logged-in on the YunoHost portal.
 sso = "false"
 
-# FIXME: replace with an **estimate** minimum disk and RAM requirements. e.g. 20M, 400M, 1G...
 disk = "700M"
 ram.build = "300M"
 ram.runtime = "30M"
@@ -109,4 +103,4 @@ ram.runtime = "30M"
 
     [resources.apt]
     # This will automatically install/uninstall the following apt packages
-    packages = "python3"
+    packages = "python3 python3-venv"

--- a/manifest.toml
+++ b/manifest.toml
@@ -22,7 +22,7 @@ code = "https://github.com/esphome/esphome"
 # to easily track CVE (=security reports) related to apps. The CPE may be obtained by searching here:
 # https://nvd.nist.gov/products/cpe/search.
 # For example, for Nextcloud, the CPE is 'cpe:2.3:a:nextcloud:nextcloud' (no need to include the version number)
-cpe = "cpe:2.3:a:esphome:esphome:-:*:*:*:*:*:*:*"
+cpe = "cpe:2.3:a:esphome:esphome"
 
 # This is meant to be an URL where people can financially support this app, especially when its development is based
 # on volunteers and/or financed by its community. YunoHost may later advertise it in the webadmin.
@@ -36,11 +36,11 @@ multi_instance = true
 
 # Not to confuse with the "sso" key: the "ldap" key corresponds to wether or not a user *can* login on the app using
 # its YunoHost credentials.
-ldap = "false"
+ldap = false
 
 # Not to confuse with the "ldap" key: the "sso" key corresponds to wether or not a user is *automatically logged-in*
 # on the app when logged-in on the YunoHost portal.
-sso = "false"
+sso = false
 
 disk = "700M"
 ram.build = "300M"

--- a/manifest.toml
+++ b/manifest.toml
@@ -103,4 +103,4 @@ ram.runtime = "30M"
 
     [resources.apt]
     # This will automatically install/uninstall the following apt packages
-    packages = "python3 python3-venv"
+    packages = "python3 python3-venv python3-wheel"


### PR DESCRIPTION
## Problem

- Multiple fixmes remained, despite being fixed
- The linter failed due to an invalid set of architectures in manifest.toml (this was set from when I planned to use docker for ESPHome, but because it just uses a python venv, it works on all architectures)
- YunoRunner failed due to python3-venv not being in the apt dependencies

## Solution

- Removed the fixme lines in manifest.toml
- Set architectures to "all"
- Added python3-venv to apt dependencies

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
