### PR TITLE
Bump esphome to 2025.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Shipped version:** 2024.12.4~ynh1
+**Shipped version:** 2025.2.0~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Versión actual:** 2024.12.4~ynh1
+**Versión actual:** 2025.2.0~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Paketatutako bertsioa:** 2024.12.4~ynh1
+**Paketatutako bertsioa:** 2025.2.0~ynh1
 
 **Demoa:** <https://web.esphome.io/>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 ESPHome est un système permettant de contrôler vos microcontrôleurs par des fichiers de configuration simples mais puissants et de les contrôler à distance par le biais de systèmes domotiques. Tout ce que vous avez à faire est d'écrire des fichiers de configuration YAML ; le reste (mises à jour over-the-air, compilation) est entièrement pris en charge par ESPHome.
 
 
-**Version incluse :** 2024.12.4~ynh1
+**Version incluse :** 2025.2.0~ynh1
 
 **Démo :** <https://web.esphome.io/>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Versión proporcionada:** 2024.12.4~ynh1
+**Versión proporcionada:** 2025.2.0~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Versi terkirim:** 2024.12.4~ynh1
+**Versi terkirim:** 2025.2.0~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Geleverde versie:** 2024.12.4~ynh1
+**Geleverde versie:** 2025.2.0~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Dostarczona wersja:** 2024.12.4~ynh1
+**Dostarczona wersja:** 2025.2.0~ynh1
 
 **Demo:** <https://web.esphome.io/>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**Поставляемая версия:** 2024.12.4~ynh1
+**Поставляемая версия:** 2025.2.0~ynh1
 
 **Демо-версия:** <https://web.esphome.io/>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 ESPHome is a system to control your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems. All you need to do is write YAML configuration files; the rest (over-the-air updates, compiling) is all handled by ESPHome.
 
 
-**分发版本：** 2024.12.4~ynh1
+**分发版本：** 2025.2.0~ynh1
 
 **演示：** <https://web.esphome.io/>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "ESPHome"
 description.en = "Build your own smart home devices using ESPHome"
 description.fr = "Créez vos propres appareils domestiques intelligents avec ESPHome"
 
-version = "2024.12.4~ynh1"
+version = "2025.2.0~ynh1"
 
 maintainers = ["WGrav01"]
 
@@ -51,8 +51,8 @@ ram.runtime = "30M"
 
     [resources.sources.main]
 
-    url = "https://github.com/esphome/esphome/archive/refs/tags/2024.12.4.tar.gz"
-    sha256 = "eb9a532cf2c218d8cd246d2793fd94ae90d53f85ed2e9a76ea1c6b5d9160a13c"
+    url = "https://github.com/esphome/esphome/archive/refs/tags/2025.2.0.tar.gz"
+    sha256 = "ad515db66cdcc544a86d64dfb3fb42366335ffab5a6261f186de15b760d7ac9d"
 
     autoupdate.strategy = "latest_github_tag"
 


### PR DESCRIPTION
## Problem

- ESPHome has released v2025.2.0, and this package is behind.

## Solution

- I bumped it in manifest.toml. There shouldn't be any breaking changes to worry about.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
